### PR TITLE
TNT-40664 - fix for DeliveryResponse notifications

### DIFF
--- a/delivery/components/DeliveryResponse.yaml
+++ b/delivery/components/DeliveryResponse.yaml
@@ -24,5 +24,6 @@ DeliveryResponse:
       $ref: "./PrefetchResponse.yaml#/PrefetchResponse"
     notifications:
       type: array
-      $ref: "./NotificationResponse.yaml#/NotificationResponse"
+      items:
+        $ref: "./NotificationResponse.yaml#/NotificationResponse"
     


### PR DESCRIPTION
Follow-up for PR https://github.com/adobe/target-openapi/pull/4
DeliveryResponse notifications field was not properly configured to be an array type