### PR TITLE
TNT-40658 - various bug fixes because java generator strictly follows Open API 3.0 spec

### DIFF
--- a/common/components/ABTOrder.yaml
+++ b/common/components/ABTOrder.yaml
@@ -15,8 +15,9 @@ ABTOrder:
       minimum: 0
       description: |
         Order Total. The amount of money in the current order.
-    time: 
-      type: date-time
+    time:
+      type: string
+      format: date-time
       description: |
         Time in the [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Time_intervals) format
     productIds:

--- a/common/components/Order.yaml
+++ b/common/components/Order.yaml
@@ -22,8 +22,9 @@ Order:
           * Product ids, separated by commas and concatenated, total length should not exceed 250.
       items:
         type: string
-    time: 
-      type: date-time
+    time:
+      type: string
+      format: date-time
       description: |
         Time in the [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Time_intervals) format
     experienceLocalId:

--- a/delivery/components/DecisioningMethod.yaml
+++ b/delivery/components/DecisioningMethod.yaml
@@ -1,4 +1,5 @@
 openapi: "3.0.0"
 DecisioningMethod:
+  x-enum-as-string: true
   type: string
   enum: ["server-side", "on-device", "hybrid"]

--- a/delivery/components/MboxResponse.yaml
+++ b/delivery/components/MboxResponse.yaml
@@ -3,7 +3,11 @@ MboxResponse:
   type: object
   description: |
     Mbox response object.
+  discriminator:
+    propertyName: $_type
   properties:
+    $_type:
+      type: string
     index:
       type: integer
       format: int32

--- a/delivery/components/RequestDetails.yaml
+++ b/delivery/components/RequestDetails.yaml
@@ -2,7 +2,11 @@ openapi: "3.0.0"
 RequestDetails:
   type: object
   description: Object common for prefetch, execute and notifications in order to specify the request details.
+  discriminator:
+    propertyName: $_type
   properties:
+    $_type:
+      type: string
     address:
       $ref: "./Address.yaml#/Address"
     parameters:

--- a/delivery/components/TelemetryEntry.yaml
+++ b/delivery/components/TelemetryEntry.yaml
@@ -14,11 +14,11 @@ TelemetryEntry:
       $ref: "./ExecutionMode.yaml#/ExecutionMode"
       description: Execution Mode for request
     execution:
-      type: integer
+      type: number
       format: double
       description: Execution time in milliseconds.
     parsing:
-      type: integer
+      type: number
       format: double
       description: Response parsing time, in milliseconds elapsed since UNIX epoch.
     features:


### PR DESCRIPTION
## Description
Most of these changes are just bug fixes in order to follow the Open API 3.0 spec.  Different generators follow the Open API spec to varying degrees when generating source code based on the yaml files.  The Java generator strictly follows the spec, thus updates needed to be made.  These changes should not break the other language generators we use for other SDKs.

## How Has This Been Tested?
These changes were tested against (and required for) the Java generator for the target-java-sdk project

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
