### PR TITLE
TNT-42499 - update TelemetryRequest fields to be double type

### DIFF
--- a/delivery/components/TelemetryRequest.yaml
+++ b/delivery/components/TelemetryRequest.yaml
@@ -4,20 +4,20 @@ TelemetryRequest:
   description: Telemetry Request
   properties:
     dns:
-      type: integer
-      format: int64
+      type: number
+      format: double
       description: DNS resolution time, in milliseconds elapsed since UNIX epoch.
     tls:
-      type: integer
-      format: int64
+      type: number
+      format: double
       description: TLS handshake time, in milliseconds elapsed since UNIX epoch.
     timeToFirstByte:
-      type: integer
-      format: int64
+      type: number
+      format: double
       description: Time to first byte, in milliseconds elapsed since UNIX epoch.
     download:
-      type: integer
-      format: int64
+      type: number
+      format: double
       description: Download time, in milliseconds elapsed since UNIX epoch.
     responseSize:
       type: integer


### PR DESCRIPTION
The request timing fields should double type - not long.  
`"request": {
          "dns": 37.70758008956909,
          "tls": 155.3639440536499,
          "timeToFirstByte": 143.5399889945984,
          "download": 2.9962620735168457,
          "parsingTime": 0.06416010856628418,
          "responseSize": 506
        }`

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
