### PR TITLE
added client hints to context

### DIFF
--- a/delivery/components/ClientHints.yaml
+++ b/delivery/components/ClientHints.yaml
@@ -1,0 +1,30 @@
+openapi: "3.0.0"
+ClientHints:
+  type: object
+  description: |
+    Client hints data.  Used in place of userAgent if provided.
+  properties:
+    mobile:
+      type: boolean
+      description: Sec-CH-UA-Mobile (low entropy)
+    model:
+      type: string
+      description: Sec-CH-UA-Model
+    platform:
+      type: string
+      description: Sec-CH-UA-Platform (low entropy)
+    platformVersion:
+      type: string
+      description: Sec-CH-UA-Platform-Version
+    browserUAWithMajorVersion:
+      type: string
+      description: Sec-CH-UA (low entropy)
+    browserUAWithFullVersion:
+      type: string
+      description: Sec-CH-UA-Full-Version-List
+    architecture:
+      type: string
+      description: Sec-CH-UA-Arch
+    bitness:
+      type: string
+      description: Sec-CH-UA-Bitness

--- a/delivery/components/Context.yaml
+++ b/delivery/components/Context.yaml
@@ -28,6 +28,8 @@ Context:
     userAgent:
       description: User-Agent should be sent only via this property. HTTP header User-Agent is ignored.
       type: string
+    clientHints:
+        $ref: "./ClientHints.yaml#/ClientHints"
     beacon:
       type: boolean
       default: false


### PR DESCRIPTION
This PR adds client hints to the `Context` Object.  Context has a new property `clientHints` whose value is a `ClientHints` object.  The `ClientHints` object has a property for each supported (low and high entropy) client hint value.  The property names to not match header names nor javascript getter names.  Instead they are logical names for target's use but the description reveals the corresponding header.

see also [this wiki](https://wiki.corp.adobe.com/pages/viewpage.action?spaceKey=Target&title=User+Agent+to+Client+Hints+Impact+Analysis)